### PR TITLE
speed dial, etc

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -6139,10 +6139,12 @@ def nerf_paladin_shield():
 
 
 def expand_rom():
-    expand_sub = Substitution()
-    expand_sub.set_location(0x300000)
-    expand_sub.bytestring = [0x00] * 0x100000
-    expand_sub.write(fout)
+    fout.seek(0,2)
+    if fout.tell() < 0x400000:
+        expand_sub = Substitution()
+        expand_sub.set_location(fout.tell())
+        expand_sub.bytestring = [0x00] * (0x400000 - fout.tell())
+        expand_sub.write(fout)
 
 
 def randomize():

--- a/randomizer.py
+++ b/randomizer.py
@@ -6264,7 +6264,7 @@ k   Randomize the clock in Zozo
                 flags = flags[1]
             fullseed = ".%s.%s" % (flags, fullseed)
             print
-    
+
     try:
         version, flags, seed = tuple(fullseed.split('.'))
     except ValueError:

--- a/randomizer.py
+++ b/randomizer.py
@@ -6225,8 +6225,11 @@ a   Organize rages alphabetically (default)
 h   Organize rages by highest level first
 g   Randomize dances
 k   Randomize the clock in Zozo
+0-9 Shorthand for the text saved under that digit, if any
 -   Use all flags EXCEPT the ones listed'''
 
+    speeddial_opts = {}
+    saveflags = False
     if len(args) > 2:
         fullseed = args[2].strip()
     else:
@@ -6234,12 +6237,34 @@ k   Randomize the clock in Zozo
                              "seed):\n> ").strip()
         print
         if '.' not in fullseed:
+            try:
+                with open('savedflags.txt', 'r') as sff:
+                    savedflags = [l.strip() for l in sff.readlines() if ":" in l]
+                    for line in savedflags:
+                        line = line.split(':')
+                        line[0] = ''.join(c for c in line[0] if c in '0123456789')
+                        speeddial_opts[line[0]] = ''.join(line[1:]).strip()
+            except IOError:
+                pass
+                
             print flaghelptext + "\n"
+            print "Save frequently used flag sets by adding 0: through 9: before the flags."
+            for k, v in sorted(speeddial_opts.items()):
+                print "    %s: %s" % (k, v)
+            print
             flags = raw_input("Please input your desired flags (blank for "
                               "all of them):\n> ").strip()
+            if ":" in flags:
+                flags = flags.split(':')
+                dial = ''.join(c for c in flags[0] if c in '0123456789')
+                if len(dial) == 1:
+                    speeddial_opts[dial] = flags[1]
+                    print '\nSaving flags "%s" in slot %s' % (flags[1], dial)
+                    saveflags = True
+                flags = flags[1]
             fullseed = ".%s.%s" % (flags, fullseed)
             print
-
+    
     try:
         version, flags, seed = tuple(fullseed.split('.'))
     except ValueError:
@@ -6252,6 +6277,14 @@ k   Randomize the clock in Zozo
     seed = seed % (10**10)
     reseed()
 
+    if saveflags:
+        try:
+            with open('savedflags.txt', 'w') as sff:
+                for k, v in speeddial_opts.items():
+                    if v: sff.write("%s: %s" % (k, v) + '\n')
+        except:
+            print "Couldn't save flag string\n"
+    
     if '.' in sourcefile:
         tempname = sourcefile.rsplit('.', 1)
     else:
@@ -6277,6 +6310,16 @@ k   Randomize the clock in Zozo
 
     copyfile(sourcefile, outfile)
 
+    flags = flags.lower()
+    flags = flags.replace('endless9', 'endless~nine~')
+    for d in "0123456789":
+        if d in speeddial_opts:
+            replacement = speeddial_opts[d]
+        else:
+            replacement = ''
+        flags = flags.replace(d, replacement)
+    flags = flags.replace('endless~nine~', 'endless9')
+
     if version and version != VERSION:
         print ("WARNING! Version mismatch! "
                "This seed will not produce the expected result!")
@@ -6292,8 +6335,6 @@ k   Randomize the clock in Zozo
     commands = dict([(c.name, c) for c in commands])
 
     characters = get_characters()
-
-    flags = flags.lower()
 
     secret_codes['airship'] = "AIRSHIP MODE"
     secret_codes['partyparty'] = "CRAZY PARTY MODE"


### PR DESCRIPTION
not sure if the basic instructions added are clear enough. clarity is not my specialty.

downside: if anyone tries to set flags BEFORE a colon, it is now ignored. this probably won't come up often.

n: (empty string after n) will delete the speed dial stored in n, this is intended.

I originally planned to redesign '-' so that it works better with these -- basically to make it so that anything after a '-' is negative, including codes, and anything before is additive, including tags. But it looks like stuff happens in the wrong order to make that feasible without a lot of rewriting, and this is good enough for now, and there are getting to be some vertical space issues anyway ... so maybe I'll direct that energy toward learning how to GUI? not sure if anything will come of that, they usually confuse the heck out of me.