### PR TITLE
Add Python 3.12 support by fixing randint() call bug

### DIFF
--- a/monsterrandomizer.py
+++ b/monsterrandomizer.py
@@ -1769,7 +1769,7 @@ def _randomweight(key: str):
               'hp': (30, 100)}
     min_weight, max_weight = ranges.get(key, (2, 100))
     delta = max_weight - min_weight
-    return min_weight + random.randint(0, delta/2 + delta%2) + random.randint(0, delta/2)
+    return min_weight + random.randint(0, delta // 2 + delta % 2) + random.randint(0, delta // 2)
 
 def monsters_from_table(tablefile):
     monsters = []


### PR DESCRIPTION
Source won't run under Python 3.12+ due to a [change to `random.randint()` and `random.randrange()`](https://docs.python.org/3/library/random.html#random.randrange). This was a small logical oops that's been present in BCEX for gods-know-how-long but Py3.12 surfaces it as a fatal exception.

Most of BCEX does the right thing but this one call to `randint()` passes a float, so this PR is a quick tweak to fix that.